### PR TITLE
feat(ui): refatora primitives para visual corporate minimalist premium

### DIFF
--- a/regulon-ai/src/app/globals.css
+++ b/regulon-ai/src/app/globals.css
@@ -3,6 +3,9 @@
 :root {
   --background: #fafafa; /* zinc-50 */
   --foreground: #18181b; /* zinc-900 */
+  --border: #e4e4e7; /* zinc-200 */
+  --card: #ffffff;
+  --card-muted: rgb(244 244 245 / 0.5); /* zinc-100/50 */
   --radius: 1rem;
 }
 
@@ -24,6 +27,7 @@ body {
   font-family: var(--font-inter), Inter, system-ui, -apple-system, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
 }
 
 ::-webkit-scrollbar {

--- a/regulon-ai/src/components/AgentProgress.tsx
+++ b/regulon-ai/src/components/AgentProgress.tsx
@@ -1,173 +1,30 @@
 'use client';
 
 import type { AgentStatus } from '@/types/compliance';
-import { Loader2, CheckCircle, AlertCircle, Circle } from 'lucide-react';
-import { motion } from 'framer-motion';
+import {
+  AgentProgress as AgentProgressPrimitive,
+  type AgentStep,
+  type AgentStepStatus,
+} from '@/components/ui/agent-progress';
 
 interface AgentProgressProps {
   agents: AgentStatus[];
-  currentAgentIndex: number;
+  currentAgentIndex?: number;
 }
 
-/**
- * Componente para visualizar o pipeline de 4 agentes em tempo real
- * Exibe status, progresso e feedbacks de cada etapa da análise regulatória
- */
-export function AgentProgress({ agents, currentAgentIndex }: AgentProgressProps) {
-  const getStatusIcon = (agent: AgentStatus, index: number) => {
-    const iconProps = {
-      className: 'w-5 h-5',
-      strokeWidth: 2.5,
-    };
+function toStepStatus(status: AgentStatus['status']): AgentStepStatus {
+  if (status === 'processando') return 'processing';
+  if (status === 'concluído') return 'done';
+  if (status === 'falhou') return 'error';
+  return 'pending';
+}
 
-    if (agent.status === 'processando') {
-      return (
-        <motion.div
-          animate={{ rotate: 360 }}
-          transition={{ duration: 2, repeat: Infinity, ease: 'linear' }}
-        >
-          <Loader2 {...iconProps} className="w-5 h-5 text-blue-500" />
-        </motion.div>
-      );
-    }
+export function AgentProgress({ agents }: AgentProgressProps) {
+  const steps = agents.map<AgentStep>(agent => ({
+    id: agent.name,
+    label: agent.displayName,
+    status: toStepStatus(agent.status),
+  }));
 
-    if (agent.status === 'concluído') {
-      return <CheckCircle {...iconProps} className="text-emerald-500" />;
-    }
-
-    if (agent.status === 'falhou') {
-      return <AlertCircle {...iconProps} className="text-red-500" />;
-    }
-
-    // pendente
-    return <Circle {...iconProps} className="text-zinc-300" />;
-  };
-
-  const getProgressBar = (agent: AgentStatus, index: number) => {
-    if (agent.status !== 'processando' && agent.status !== 'concluído') {
-      return null;
-    }
-
-    const targetProgress = agent.status === 'concluído' ? 100 : agent.progress;
-
-    return (
-      <motion.div
-        initial={{ width: 0 }}
-        animate={{ width: `${targetProgress}%` }}
-        transition={{ duration: 0.5, ease: 'easeOut' }}
-        className={`h-1 rounded-full ${
-          agent.status === 'concluído'
-            ? 'bg-emerald-500'
-            : 'bg-blue-500'
-        }`}
-      />
-    );
-  };
-
-  const getStatusLabel = (agent: AgentStatus) => {
-    const labels = {
-      pendente: 'Aguardando',
-      processando: 'Processando',
-      concluído: 'Concluído',
-      falhou: 'Erro',
-    };
-    return labels[agent.status];
-  };
-
-  return (
-    <div className="w-full max-w-2xl">
-      {/* Header */}
-      <div className="flex items-center justify-between mb-4 px-1">
-        <h3 className="text-xs font-bold uppercase tracking-wider text-zinc-600">
-          Pipeline de Análise Regulatória
-        </h3>
-        <span className="text-[10px] text-zinc-400">
-          {currentAgentIndex + 1}/4 agentes
-        </span>
-      </div>
-
-      {/* Agent Pipeline */}
-      <div className="space-y-3">
-        {agents.map((agent, index) => (
-          <motion.div
-            key={agent.id}
-            initial={{ opacity: 0, x: -10 }}
-            animate={{ opacity: 1, x: 0 }}
-            transition={{ delay: index * 0.1 }}
-            className={`flex items-start gap-4 p-3 rounded-lg border transition-colors ${
-              agent.status === 'processando'
-                ? 'bg-blue-50/50 border-blue-200'
-                : agent.status === 'concluído'
-                  ? 'bg-emerald-50/50 border-emerald-200'
-                  : agent.status === 'falhou'
-                    ? 'bg-red-50/50 border-red-200'
-                    : 'bg-zinc-50/50 border-zinc-200'
-            }`}
-          >
-            {/* Left: Sequential Number + Icon */}
-            <div className="flex items-center gap-2 flex-shrink-0">
-              <div className="w-6 h-6 flex items-center justify-center bg-white rounded border border-zinc-200 text-[10px] font-bold text-zinc-600">
-                {index + 1}
-              </div>
-              <div className="flex-shrink-0">
-                {getStatusIcon(agent, index)}
-              </div>
-            </div>
-
-            {/* Middle: Name, Status Label, and Progress Bar */}
-            <div className="flex-1 min-w-0">
-              {/* Agent Name and Status Label */}
-              <div className="flex items-center justify-between gap-2 mb-2">
-                <span className="text-sm font-bold text-zinc-900">
-                  {agent.displayName}
-                </span>
-                <span
-                  className={`text-[10px] font-medium ${
-                    agent.status === 'processando'
-                      ? 'text-blue-600'
-                      : agent.status === 'concluído'
-                        ? 'text-emerald-600'
-                        : agent.status === 'falhou'
-                          ? 'text-red-600'
-                          : 'text-zinc-500'
-                  }`}
-                >
-                  {getStatusLabel(agent)}
-                </span>
-              </div>
-
-              {/* Progress Bar */}
-              <div className="bg-zinc-200/50 rounded-full overflow-hidden h-1.5">
-                {getProgressBar(agent, index)}
-              </div>
-
-              {/* Message or Meta Info */}
-              {agent.message && (
-                <p className="text-[10px] text-zinc-600 mt-2 leading-snug">
-                  {agent.message}
-                </p>
-              )}
-              {agent.startTime && agent.endTime && (
-                <p className="text-[9px] text-zinc-400 mt-1">
-                  Tempo: {((agent.endTime - agent.startTime) / 1000).toFixed(2)}s
-                </p>
-              )}
-            </div>
-          </motion.div>
-        ))}
-      </div>
-
-      {/* Footer: Overall Progress */}
-      <div className="mt-4 pt-3 border-t border-zinc-200/50">
-        <div className="flex items-center justify-between text-[10px] text-zinc-500">
-          <span>Progresso Geral</span>
-          <span className="font-mono font-bold">
-            {Math.round(
-              (agents.filter(a => a.status === 'concluído').length / agents.length) * 100
-            )}%
-          </span>
-        </div>
-      </div>
-    </div>
-  );
+  return <AgentProgressPrimitive steps={steps} />;
 }

--- a/regulon-ai/src/components/Dashboard.tsx
+++ b/regulon-ai/src/components/Dashboard.tsx
@@ -2,7 +2,7 @@
 
 import type { RegulationImpact } from '@/types/compliance';
 import { FileText, ArrowRight, AlertTriangle } from 'lucide-react';
-import { motion } from 'framer-motion';
+import { Badge } from '@/components/ui/badge';
 
 interface DashboardProps {
   analysisActive: boolean;
@@ -11,17 +11,7 @@ interface DashboardProps {
 }
 
 const ImpactBadge = ({ level }: { level: RegulationImpact['impactLevel'] }) => {
-  const styles = {
-    CRITICAL: 'bg-red-50 text-red-700 border-red-200',
-    HIGH: 'bg-orange-50 text-orange-700 border-orange-200',
-    MEDIUM: 'bg-yellow-50 text-yellow-700 border-yellow-200',
-    LOW: 'bg-green-50 text-green-700 border-green-200',
-  };
-  return (
-    <span className={`px-2 py-0.5 text-[10px] font-bold border rounded-full ${styles[level]}`}>
-      {level}
-    </span>
-  );
+  return <Badge impactLevel={level}>{level}</Badge>;
 };
 
 export function Dashboard({ analysisActive, impacts, handleFileUpload }: DashboardProps) {

--- a/regulon-ai/src/components/ui/agent-progress.tsx
+++ b/regulon-ai/src/components/ui/agent-progress.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import {
+  Circle,
+  CheckCircle2,
+  Loader2,
+  AlertCircle,
+  Fingerprint,
+  Link2,
+  Scale,
+  ListChecks,
+} from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+export type AgentStepStatus = 'pending' | 'processing' | 'done' | 'error';
+
+export interface AgentStep {
+  id: 'classificador' | 'matching' | 'interpretador' | 'executor';
+  label: string;
+  status: AgentStepStatus;
+}
+
+interface AgentProgressProps {
+  steps?: AgentStep[];
+}
+
+const defaultSteps: AgentStep[] = [
+  { id: 'classificador', label: 'Classificador', status: 'pending' },
+  { id: 'matching', label: 'Matching', status: 'pending' },
+  { id: 'interpretador', label: 'Interpretador', status: 'pending' },
+  { id: 'executor', label: 'Executor', status: 'pending' },
+];
+
+const iconByStep = {
+  classificador: Fingerprint,
+  matching: Link2,
+  interpretador: Scale,
+  executor: ListChecks,
+};
+
+function StatusDot({ status }: { status: AgentStepStatus }) {
+  if (status === 'processing') {
+    return <Loader2 className="h-4 w-4 animate-spin text-zinc-700" />;
+  }
+  if (status === 'done') {
+    return <CheckCircle2 className="h-4 w-4 text-zinc-900" />;
+  }
+  if (status === 'error') {
+    return <AlertCircle className="h-4 w-4 text-red-600" />;
+  }
+  return <Circle className="h-4 w-4 text-zinc-300" />;
+}
+
+export function AgentProgress({ steps = defaultSteps }: AgentProgressProps) {
+  return (
+    <div className="rounded-2xl border border-zinc-200 bg-zinc-50 p-4 shadow-sm shadow-zinc-900/5">
+      <div className="mb-3 flex items-center justify-between">
+        <p className="text-[10px] font-semibold uppercase tracking-[0.12em] text-zinc-500">
+          Pipeline de Agentes
+        </p>
+        <p className="text-[10px] text-zinc-500">
+          {steps.filter(step => step.status === 'done').length}/4 concluídos
+        </p>
+      </div>
+
+      <div className="grid gap-2 sm:grid-cols-4">
+        {steps.map((step, index) => {
+          const StepIcon = iconByStep[step.id];
+
+          return (
+            <motion.div
+              key={step.id}
+              initial={{ opacity: 0, y: 4 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: index * 0.05, duration: 0.2 }}
+              className={cn(
+                'relative rounded-2xl border px-3 py-3',
+                'bg-white shadow-sm shadow-zinc-900/5',
+                step.status === 'processing' && 'border-zinc-400',
+                step.status === 'done' && 'border-zinc-900',
+                step.status === 'error' && 'border-red-300',
+                step.status === 'pending' && 'border-zinc-200',
+              )}
+            >
+              <div className="mb-2 flex items-center justify-between">
+                <StepIcon className="h-4 w-4 text-zinc-600" />
+                <StatusDot status={step.status} />
+              </div>
+
+              <p className="text-[10px] font-semibold uppercase tracking-wide text-zinc-700">
+                {step.label}
+              </p>
+
+              {index < steps.length - 1 && (
+                <span className="pointer-events-none absolute -right-1 top-1/2 hidden h-px w-2 bg-zinc-300 sm:block" />
+              )}
+            </motion.div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/regulon-ai/src/components/ui/badge.tsx
+++ b/regulon-ai/src/components/ui/badge.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+type ImpactLevel = 'CRITICAL' | 'HIGH' | 'MEDIUM' | 'LOW';
+
+const impactStyles: Record<ImpactLevel, string> = {
+  CRITICAL: 'bg-zinc-900 text-zinc-50 border-zinc-900',
+  HIGH: 'bg-zinc-800 text-zinc-100 border-zinc-700',
+  MEDIUM: 'bg-zinc-200 text-zinc-800 border-zinc-300',
+  LOW: 'bg-zinc-100 text-zinc-600 border-zinc-200',
+};
+
+export interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
+  impactLevel?: ImpactLevel;
+}
+
+export function Badge({ className, impactLevel = 'LOW', ...props }: BadgeProps) {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center rounded-full border px-2.5 py-1 text-[10px] font-semibold tracking-wide',
+        impactStyles[impactLevel],
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/regulon-ai/src/components/ui/button.tsx
+++ b/regulon-ai/src/components/ui/button.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'destructive';
+type ButtonSize = 'sm' | 'md' | 'lg' | 'icon';
+
+const variantClasses: Record<ButtonVariant, string> = {
+  primary:
+    'bg-zinc-900 text-zinc-50 border-zinc-900 hover:bg-zinc-800 focus-visible:ring-zinc-900',
+  secondary:
+    'bg-zinc-100 text-zinc-900 border-zinc-200 hover:bg-zinc-200 focus-visible:ring-zinc-400',
+  ghost:
+    'bg-transparent text-zinc-900 border-transparent hover:bg-zinc-100 focus-visible:ring-zinc-400',
+  destructive:
+    'bg-red-600 text-white border-red-600 hover:bg-red-500 focus-visible:ring-red-600',
+};
+
+const sizeClasses: Record<ButtonSize, string> = {
+  sm: 'h-11 px-4 text-sm',
+  md: 'h-11 px-5 text-sm',
+  lg: 'h-12 px-6 text-base',
+  icon: 'h-11 w-11',
+};
+
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+}
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant = 'primary', size = 'md', type = 'button', ...props }, ref) => {
+    return (
+      <button
+        ref={ref}
+        type={type}
+        className={cn(
+          'inline-flex items-center justify-center gap-2 rounded-2xl border shadow-sm shadow-zinc-900/5',
+          'font-medium whitespace-nowrap transition-colors duration-150',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-50',
+          'disabled:pointer-events-none disabled:opacity-50',
+          variantClasses[variant],
+          sizeClasses[size],
+          className,
+        )}
+        {...props}
+      />
+    );
+  },
+);
+
+Button.displayName = 'Button';

--- a/regulon-ai/src/components/ui/card.tsx
+++ b/regulon-ai/src/components/ui/card.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
+  muted?: boolean;
+}
+
+export function Card({ className, muted = false, ...props }: CardProps) {
+  return (
+    <div
+      className={cn(
+        'rounded-2xl border border-zinc-200 shadow-sm shadow-zinc-900/5',
+        muted ? 'bg-zinc-50/50' : 'bg-white',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function CardHeader({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('px-6 pt-6', className)} {...props} />;
+}
+
+export function CardTitle({ className, ...props }: React.HTMLAttributes<HTMLHeadingElement>) {
+  return <h3 className={cn('text-base font-semibold text-zinc-900', className)} {...props} />;
+}
+
+export function CardDescription({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLParagraphElement>) {
+  return <p className={cn('text-sm text-zinc-500', className)} {...props} />;
+}
+
+export function CardContent({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('px-6 py-4', className)} {...props} />;
+}
+
+export function CardFooter({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('px-6 pb-6 pt-2', className)} {...props} />;
+}

--- a/regulon-ai/src/components/ui/input.tsx
+++ b/regulon-ai/src/components/ui/input.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
+
+export const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type = 'text', ...props }, ref) => {
+    return (
+      <input
+        ref={ref}
+        type={type}
+        className={cn(
+          'flex h-11 w-full min-w-0 rounded-2xl border border-zinc-200 bg-zinc-50 px-4 py-2 text-sm text-zinc-900 shadow-sm shadow-zinc-900/5',
+          'placeholder:text-zinc-400',
+          'outline-none transition-colors',
+          'focus:border-zinc-900 focus:ring-2 focus:ring-zinc-900/15',
+          'disabled:cursor-not-allowed disabled:opacity-50',
+          className,
+        )}
+        {...props}
+      />
+    );
+  },
+);
+
+Input.displayName = 'Input';


### PR DESCRIPTION
- adiciona overrides em src/components/ui para Button, Card, Input e Badge
 - padroniza rounded-2xl, paleta Zinc e shadow-sm com foco em consistência visual
 - garante touch targets mobile (h-11) em componentes interativos base
 - cria novo src/components/ui/agent-progress.tsx com microanimações e 4 estágios
 - adapta src/components/AgentProgress.tsx para consumir o novo primitive
 - atualiza globals.css com tokens visuais (border/card) e legibilidade (optimizeLegibility)

closes #13